### PR TITLE
Feature: support tagging for writing S3 objects

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -1123,6 +1123,21 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 		}
 		dopts.Metadata = md
 	}
+
+	if len(opts.Tags) > 0 {
+		tags := make(map[string]string, len(opts.Tags))
+		for k, v := range opts.Tags {
+			if k == "" {
+				return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "blob: WriterOptions.Tags keys may not be empty strings")
+			}
+			if v == "" {
+				return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "blob: WriterOptions.Tags values may not be empty strings")
+			}
+			tags[k] = v
+		}
+		dopts.Tags = tags
+	}
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.closed {
@@ -1430,6 +1445,10 @@ type WriterOptions struct {
 	// be left untouched. An error for which gcerrors.Code will return
 	// gcerrors.PreconditionFailed will be returned by Write or Close.
 	IfNotExist bool
+
+	// Tags holds key/value tags to be associated with the blob, or nil.
+	// Keys and values must be not empty if specified.
+	Tags map[string]string
 }
 
 // CopyOptions sets options for Copy.

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -115,6 +115,10 @@ type WriterOptions struct {
 	// When set to true, if a blob exists for the same key in the bucket, the write operation
 	// won't take place.
 	IfNotExist bool
+
+	// Tags holds key/value tags to be associated with the blob, or nil.
+	// Keys and values must be not empty if specified.
+	Tags map[string]string
 }
 
 // CopyOptions controls options for Copy.


### PR DESCRIPTION
Adds the option to tag S3 objects for writing objects via extendng `WriterOptions`.

Example:

```
err = bucket.WriteAll(ctx, someKey, []byte{}, &blob.WriterOptions{
	Tags: map[string]string{
		"foo": "bar",
	},
})
```

Result:

<img width="1213" alt="Screenshot 2025-06-02 at 11 39 05 AM" src="https://github.com/user-attachments/assets/108249a2-0df2-4b75-bb68-af3f93527a27" />
