### PR TITLE
Feature: send `x-amz-tagging` if only if tags are set

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -762,14 +762,16 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 		md[k] = url.PathEscape(v)
 	}
 
-	encodedTags := encodeTags(opts.Tags)
-
 	req := &s3.PutObjectInput{
 		Bucket:      aws.String(b.name),
 		ContentType: aws.String(contentType),
 		Key:         aws.String(key),
 		Metadata:    md,
-		Tagging:     aws.String(encodedTags),
+	}
+
+	if len(opts.Tags) > 0 {
+		encodedTags := encodeTags(opts.Tags)
+		req.Tagging = aws.String(encodedTags)
 	}
 
 	if opts.IfNotExist {


### PR DESCRIPTION
Avoids sending `x-amz-tagging` header with S3 PUT requests always, send only if tags are set.