### PR TITLE
Feature: allow tagging for S3 copying

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -1216,6 +1216,7 @@ func (b *Bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *CopyOpti
 	}
 	dopts := &driver.CopyOptions{
 		BeforeCopy: opts.BeforeCopy,
+		Tags:       opts.Tags,
 	}
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -1459,6 +1460,10 @@ type CopyOptions struct {
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeCopy func(asFunc func(any) bool) error
+
+	// Tags holds key/value tags to be associated with the blob, or nil.
+	// Keys and values must be not empty if specified.
+	Tags map[string]string
 }
 
 // BucketURLOpener represents types that can open buckets based on a URL.

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -127,6 +127,10 @@ type CopyOptions struct {
 	// asFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
 	BeforeCopy func(asFunc func(any) bool) error
+
+	// Tags holds key/value tags to be associated with the blob, or nil.
+	// Keys and values must be not empty if specified.
+	Tags map[string]string
 }
 
 // ReaderAttributes contains a subset of attributes about a blob that are

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -853,6 +853,11 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	if b.kmsKeyId != "" {
 		input.SSEKMSKeyId = aws.String(b.kmsKeyId)
 	}
+	if len(opts.Tags) > 0 {
+		encodedTags := encodeTags(opts.Tags)
+		input.Tagging = aws.String(encodedTags)
+	}
+	
 	if opts.BeforeCopy != nil {
 		asFunc := func(i any) bool {
 			switch v := i.(type) {


### PR DESCRIPTION
Allows to pass tags for objects copying:

Example:

```
err := bucket.Copy(ctx, object.destinationKey, key, &blob.CopyOptions{
	Tags: map[string]string{
		"foo": "bar",
	},
})
```

Gives:

<img width="1202" alt="Screenshot 2025-06-03 at 11 33 36 AM" src="https://github.com/user-attachments/assets/4cbb13af-fd1e-4fc0-ad09-5f101cbc735a" />

