### PR TITLE
ci: allow grid private Go module reads

### DIFF
--- a/.github/chainguard/grid-go-modules-read.sts.yaml
+++ b/.github/chainguard/grid-go-modules-read.sts.yaml
@@ -1,0 +1,29 @@
+issuer: https://token.actions.githubusercontent.com
+# Used by gridai/grid CI to download this private repository as a Go module.
+# Keep this read-only; Grid exchanges one token per private module repository.
+subject_pattern: "repo:gridai/grid:(pull_request|ref:refs/heads/.*)"
+audience: octo-sts.gridai.dev
+claim_pattern:
+  workflow_ref: "gridai/grid/\\.github/workflows/(\
+    _test-studio-e2e\\.yml|\
+    _test-studio-e2e-staging\\.yml|\
+    build-and-upload-baremetal-agent\\.yml|\
+    build-and-upload-lightning-agent\\.yml|\
+    build-and-upload-lightning-settings-server\\.yml|\
+    build-dockers\\.yml|\
+    lint-go\\.yaml|\
+    lint-pre-commit\\.yaml|\
+    test-backend\\.yml|\
+    test-baremetal-agent\\.yml|\
+    test-e2e\\.yml|\
+    test-flakiness-go-unit-tests\\.yml|\
+    test-flakiness-individual-spec\\.yml|\
+    test-full-with-deploy\\.yml|\
+    test-sdk-integration\\.yml|\
+    test-sdk-staging\\.yml|\
+    test-staging\\.yml|\
+    test-with-tired-proxy\\.yml\
+    )@.*"
+
+permissions:
+  contents: read


### PR DESCRIPTION
This pull request adds a new configuration file to support secure, read-only access for CI workflows that need to download this private repository as a Go module. The file defines issuer, audience, subject, claims, and permissions to enforce access control.

**CI/CD and Security Configuration:**

* Added `.github/chainguard/grid-go-modules-read.sts.yaml` to configure STS permissions for CI workflows, allowing only specific workflows in the `gridai/grid` repository to download this repository as a Go module with read-only access.